### PR TITLE
OZ-575: Install `python-jose` required by `auth_oidc*` addons.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,8 @@ RUN  arch=$(arch | sed s/aarch64/arm64/ | sed s/x86_64/amd64/) && \
 RUN pip3 install --upgrade pip
 RUN pip3 install phonenumbers
 RUN pip3 install python-jose
+RUN pip install pip setuptools wheel Cython==3.0.0a10
+RUN pip install gevent==20.9.0 --no-build-isolation
 RUN npm install -g rtlcss
 
 RUN mkdir -p /opt/odoo

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN  arch=$(arch | sed s/aarch64/arm64/ | sed s/x86_64/amd64/) && \
     wget https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.buster_${arch}.deb && \
     dpkg -i wkhtmltox_0.12.6-1.buster_${arch}.deb &&  cp /usr/local/bin/wkhtmltopdf /usr/bin && cp /usr/local/bin/wkhtmltoimage /usr/bin
 RUN pip install phonenumbers
+RUN pip install python-jose
 RUN npm install -g rtlcss
 
 RUN mkdir -p /opt/odoo

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,14 +11,14 @@ RUN apt update && apt install -y git npm postgresql-client python3-dev libxml2-d
 RUN  arch=$(arch | sed s/aarch64/arm64/ | sed s/x86_64/amd64/) && \
     wget https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-3/wkhtmltox_0.12.6.1-3.bookworm_${arch}.deb && \
     dpkg -i wkhtmltox_0.12.6.1-3.bookworm_${arch}.deb &&  cp /usr/local/bin/wkhtmltopdf /usr/bin && cp /usr/local/bin/wkhtmltoimage /usr/bin
-RUN pip3 install phonenumbers
-RUN pip3 install python-jose
+RUN pip install phonenumbers
+RUN pip install python-jose
 RUN npm install -g rtlcss
 
 RUN mkdir -p /opt/odoo
 RUN cd /tmp/ && wget https://github.com/mekomsolutions/odoo/archive/refs/heads/${ODOO_BRANCH}.zip \
     && unzip /tmp/${ODOO_BRANCH}.zip && mv /tmp/odoo-${ODOO_BRANCH}/* /opt/odoo/ && rm /tmp/${ODOO_BRANCH}.zip
-RUN cd /opt/odoo && pip3 install -r requirements.txt
+RUN cd /opt/odoo && pip install -r requirements.txt
 
 # Expose Odoo services
 EXPOSE 8069 8071 8072

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN apt update && apt install -y git npm postgresql-client python3-dev libxml2-d
 RUN  arch=$(arch | sed s/aarch64/arm64/ | sed s/x86_64/amd64/) && \
     wget https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-3/wkhtmltox_0.12.6.1-3.bookworm_${arch}.deb && \
     dpkg -i wkhtmltox_0.12.6.1-3.bookworm_${arch}.deb &&  cp /usr/local/bin/wkhtmltopdf /usr/bin && cp /usr/local/bin/wkhtmltoimage /usr/bin
+RUN pip install --upgrade pip
 RUN pip install phonenumbers
 RUN pip install python-jose
 RUN npm install -g rtlcss

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,14 +11,14 @@ RUN apt update && apt install -y git npm postgresql-client python3-dev libxml2-d
 RUN  arch=$(arch | sed s/aarch64/arm64/ | sed s/x86_64/amd64/) && \
     wget https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-3/wkhtmltox_0.12.6.1-3.bookworm_${arch}.deb && \
     dpkg -i wkhtmltox_0.12.6.1-3.bookworm_${arch}.deb &&  cp /usr/local/bin/wkhtmltopdf /usr/bin && cp /usr/local/bin/wkhtmltoimage /usr/bin
-RUN pip install phonenumbers
-RUN pip install python-jose
+RUN pip3 install phonenumbers
+RUN pip3 install python-jose
 RUN npm install -g rtlcss
 
 RUN mkdir -p /opt/odoo
 RUN cd /tmp/ && wget https://github.com/mekomsolutions/odoo/archive/refs/heads/${ODOO_BRANCH}.zip \
     && unzip /tmp/${ODOO_BRANCH}.zip && mv /tmp/odoo-${ODOO_BRANCH}/* /opt/odoo/ && rm /tmp/${ODOO_BRANCH}.zip
-RUN cd /opt/odoo && pip install -r requirements.txt
+RUN cd /opt/odoo && pip3 install -r requirements.txt
 
 # Expose Odoo services
 EXPOSE 8069 8071 8072

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,15 +11,15 @@ RUN apt update && apt install -y git npm postgresql-client python3-dev libxml2-d
 RUN  arch=$(arch | sed s/aarch64/arm64/ | sed s/x86_64/amd64/) && \
     wget https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-3/wkhtmltox_0.12.6.1-3.bookworm_${arch}.deb && \
     dpkg -i wkhtmltox_0.12.6.1-3.bookworm_${arch}.deb &&  cp /usr/local/bin/wkhtmltopdf /usr/bin && cp /usr/local/bin/wkhtmltoimage /usr/bin
-RUN pip install --upgrade pip
-RUN pip install phonenumbers
-RUN pip install python-jose
+RUN pip3 install --upgrade pip3
+RUN pip3 install phonenumbers
+RUN pip3 install python-jose
 RUN npm install -g rtlcss
 
 RUN mkdir -p /opt/odoo
 RUN cd /tmp/ && wget https://github.com/mekomsolutions/odoo/archive/refs/heads/${ODOO_BRANCH}.zip \
     && unzip /tmp/${ODOO_BRANCH}.zip && mv /tmp/odoo-${ODOO_BRANCH}/* /opt/odoo/ && rm /tmp/${ODOO_BRANCH}.zip
-RUN cd /opt/odoo && pip install -r requirements.txt
+RUN cd /opt/odoo && pip3 install -r requirements.txt
 
 # Expose Odoo services
 EXPOSE 8069 8071 8072

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt update && apt install -y git npm postgresql-client python3-dev libxml2-d
 RUN  arch=$(arch | sed s/aarch64/arm64/ | sed s/x86_64/amd64/) && \
     wget https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-3/wkhtmltox_0.12.6.1-3.bookworm_${arch}.deb && \
     dpkg -i wkhtmltox_0.12.6.1-3.bookworm_${arch}.deb &&  cp /usr/local/bin/wkhtmltopdf /usr/bin && cp /usr/local/bin/wkhtmltoimage /usr/bin
-RUN pip3 install --upgrade pip3
+RUN pip3 install --upgrade pip
 RUN pip3 install phonenumbers
 RUN pip3 install python-jose
 RUN npm install -g rtlcss

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,11 @@ ARG ODOO_BRANCH=14.0
 
 # Install dependencies
 RUN apt update && apt install -y git npm postgresql-client python3-dev libxml2-dev libxslt1-dev libldap2-dev libsasl2-dev \
-    libtiff5-dev zlib1g-dev libfreetype6-dev wait-for-it xvfb libfontconfig  wget \
+    libtiff5-dev zlib1g-dev libfreetype6-dev wait-for-it xvfb libfontconfig fontconfig wget \
     liblcms2-dev libwebp-dev libharfbuzz-dev libfribidi-dev libxcb1-dev libpq-dev gettext-base unzip xfonts-75dpi xfonts-base
 RUN  arch=$(arch | sed s/aarch64/arm64/ | sed s/x86_64/amd64/) && \
-    wget https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.buster_${arch}.deb && \
-    dpkg -i wkhtmltox_0.12.6-1.buster_${arch}.deb &&  cp /usr/local/bin/wkhtmltopdf /usr/bin && cp /usr/local/bin/wkhtmltoimage /usr/bin
+    wget https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-3/wkhtmltox_0.12.6.1-3.bookworm_${arch}.deb && \
+    dpkg -i wkhtmltox_0.12.6.1-3.bookworm_${arch}.deb &&  cp /usr/local/bin/wkhtmltopdf /usr/bin && cp /usr/local/bin/wkhtmltoimage /usr/bin
 RUN pip install phonenumbers
 RUN pip install python-jose
 RUN npm install -g rtlcss


### PR DESCRIPTION
[OZ-575](https://mekomsolutions.atlassian.net/browse/OZ-575) - Odoo logout with Keycloak

[OZ-575]: https://mekomsolutions.atlassian.net/browse/OZ-575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ