### PR TITLE
OZ-573: Add environment variable substitution for CSV files in initializer data directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG ODOO_BRANCH=14.0
 
 # Install dependencies
 RUN apt update && apt install -y git npm postgresql-client python3-dev libxml2-dev libxslt1-dev libldap2-dev libsasl2-dev \
-    libtiff5-dev zlib1g-dev libfreetype6-dev wait-for-it xvfb libfontconfig fontconfig wget \
+    libtiff5-dev zlib1g-dev libfreetype6-dev wait-for-it xvfb libfontconfig moreutils fontconfig wget \
     liblcms2-dev libwebp-dev libharfbuzz-dev libfribidi-dev libxcb1-dev libpq-dev gettext-base unzip xfonts-75dpi xfonts-base
 RUN  arch=$(arch | sed s/aarch64/arm64/ | sed s/x86_64/amd64/) && \
     wget https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-3/wkhtmltox_0.12.6.1-3.bookworm_${arch}.deb && \

--- a/resources/entrypoint.sh
+++ b/resources/entrypoint.sh
@@ -33,6 +33,13 @@ if [ -d /etc/properties ]; then
     done
 fi
 
+# env vars substitution for csv files in ${INITIALIZER_DATA_FILES_PATH} directory
+if [ -d "${INITIALIZER_DATA_FILES_PATH}" ]; then
+    for file in "${INITIALIZER_DATA_FILES_PATH}"/**/*.csv; do
+        envsubst < "${file}" | sponge "${file}"
+    done
+fi
+
 extra_addons=""
 if [ ! -z "$ADDONS_LIST" ]; then
     addonsList="-i $ADDONS_LIST"


### PR DESCRIPTION
Issue: https://mekomsolutions.atlassian.net/browse/OZ-573

This PR;
- Implements environment variable substitution for CSV files located in the ${INITIALIZER_DATA_FILES_PATH} directory.
- Ensures that any environment variables present in the CSV files are replaced with their corresponding values.
- Utilizes `envsubst` for substitution and `sponge` to handle in-place file editing.